### PR TITLE
Fix ePub metadata

### DIFF
--- a/en/book.json
+++ b/en/book.json
@@ -1,8 +1,8 @@
 {
-    "title": "Soveranía Technológica",
-    "description": "Dossier Ritimo",
+    "title": " Technological Sovereignty, Vol. 2",
+    "description": "We deserve to have other technologies, something better than what we nowadays call “Information and Communication Technologies”.  This book deals with its psychological, social, political, ecological and economic costs while it relates experiences to create Technological Sovereignty.  The authors bring us closer to other ways of desiring, designing, producing and maintaining technologies.  Experiences and initiatives to develop freedom, autonomy and social justice while creating autonomous mobile telephony systems, simultaneous translation networks, leaks platforms, security tools, sovereign algorithms ethical servers and appropriate technologies among others.  The texts are by Alex Haché, Benjamin Cadon, COATI, Carolina, Kali Kaneko, Loreto Bravo, Maxigas and Margarita Padilla.",
     "author": "ed. Alex Haché",
-    "language": "es",
+    "language": "en",
     "pdf": {
         "paperSize": "a5"
     }

--- a/es/book.json
+++ b/es/book.json
@@ -1,6 +1,6 @@
 {
-    "title": "Soveranía Technológica",
-    "description": "Dossier Ritimo",
+    "title": "Soberanía tecnológica, vol. 2",
+    "description": "Nos merecemos otras tecnologías, algo mejor que lo que hoy en día llamamos «Tecnologías de Información y Comunicación».  Este libro trata de sus costes psicológicos, sociales, políticos, ecológicos y economícos mientras relata experiencias para crear Soberanía Tecnológica. Las autoras nos acercan a otros modos de desearlas, diseñarlas, producirlas y mantenerlas. Experiencias e iniciativas para desarrollar libertad, autonomía y justicia social mientras se crean sistemas autonómos de telefonía móvil, redes de traducción simultánea, plataformas de leaks, herramientas de seguridad, algoritmos soberanos, servidores éticos y tecnológias apropiadas entre otras. Los textos son de Alex Haché, Benjamin Cadon, COATI, Carolina, Claudio Agosti, Elleflâne, Framasoft + AMIPO, Ippolita, Kali Kaneko, Loreto Bravo, Maxigas y Margarita Padilla.",
     "author": "ed. Alex Haché",
     "language": "es",
     "pdf": {

--- a/fr/book.json
+++ b/fr/book.json
@@ -1,8 +1,8 @@
 {
-    "title": "Soveranía Technológica",
-    "description": "Dossier Ritimo",
+    "title": "La Souveraineté technologique, Vol. 2",
+    "description": "Nous méritons d’autres technologies, quelque chose de mieux que ce que nous appelons aujurd’hui les « Technologies de l’Information et de la communication ».  Ce livre aborde des aspects sociaux, politiques, écologiques et économiques à travers des expériences visant à développer des formes de Souveraineté Technologique.  Les auteur.e.s nous invitent à partager d’autres façons de désirer, concevoir, produire et maintenir des technologies.  Des expériences et initiatives pour développer la liberté, l’autonomie et la justice sociale tout en créant des systèmes autonomes de téléphonie mobile, des résaux de traduction simultanée, des plateformes pour lancer des alertes, des outils numériques sures, des algorithmes souverains, des serveurs éthiques et des technologies appropriées.  Les textes sont d’Alex Haché, Benjamin Cadon, COATI, Carolina, Kali Kaneko, Loreto Bravo, Maxigas and Margarita Padilla.",
     "author": "ed. Alex Haché",
-    "language": "es",
+    "language": "fr",
     "pdf": {
         "paperSize": "a5"
     }

--- a/or/book.json
+++ b/or/book.json
@@ -1,8 +1,7 @@
 {
-    "title": "Soveranía Technológica",
-    "description": "Dossier Ritimo",
+    "title": "Technological Sovereignty, Vol. 2",
+    "description": "<p><strong>Note: This version contains chapters in the language they were <em>originally</em> written by contributors.</strong></p><p>We deserve to have other technologies, something better than what we nowadays call “Information and Communication Technologies”.  This book deals with its psychological, social, political, ecological and economic costs while it relates experiences to create Technological Sovereignty.  The authors bring us closer to other ways of desiring, designing, producing and maintaining technologies.  Experiences and initiatives to develop freedom, autonomy and social justice while creating autonomous mobile telephony systems, simultaneous translation networks, leaks platforms, security tools, sovereign algorithms ethical servers and appropriate technologies among others.  The texts are by Alex Haché, Benjamin Cadon, COATI, Carolina, Kali Kaneko, Loreto Bravo, Maxigas and Margarita Padilla.</p>",
     "author": "ed. Alex Haché",
-    "language": "es",
     "pdf": {
         "paperSize": "a5"
     }


### PR DESCRIPTION
Initially removed `title` and `description` properties, because as explained in official [docs][1], they are supossedly "automatically extracted from the README".

After checking falsy this claim with "gitbook epub" command, `title` and `description` where manually extracted from each README.md and filed in their respective `book.json`

[1]: https://toolchain.gitbook.com/config.html#general-settings